### PR TITLE
Fix Input docs typo

### DIFF
--- a/cmdk/src/index.tsx
+++ b/cmdk/src/index.tsx
@@ -782,7 +782,7 @@ const Separator = React.forwardRef<HTMLDivElement, SeparatorProps>((props, forwa
 
 /**
  * Command menu input.
- * All props are forwarded to the underyling `input` element.
+ * All props are forwarded to the underlying `input` element.
  */
 const Input = React.forwardRef<HTMLInputElement, InputProps>((props, forwardedRef) => {
   const { onValueChange, ...etc } = props


### PR DESCRIPTION
## Summary
- fix a spelling mistake in the Input component docs

## Testing
- `pnpm test:format` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.8.0.tgz)*
- `pnpm test` *(fails: Error when performing the request to https://registry.npmjs.org/pnpm/-/pnpm-8.8.0.tgz)*